### PR TITLE
Bootstrap jira sync bot config

### DIFF
--- a/.github/.jira_sync_config.yaml
+++ b/.github/.jira_sync_config.yaml
@@ -1,0 +1,16 @@
+# See https://github.com/canonical/gh-jira-sync-bot for config
+settings:
+  jira_project_key: "ISD"
+  
+  status_mapping:
+    opened: Untriaged
+    closed: Done
+    not_planned: Rejected
+    
+  add_gh_comment: true
+  
+  epic_key: ISD-3981
+      
+  label_mapping:
+    bug: Bug
+    enhancement: Story

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: File a bug report
-labels: ["Type: Bug", "Status: Triage"]
+labels: ["bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/enhancement_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement_proposal.yml
@@ -1,6 +1,6 @@
 name: Enhancement Proposal
 description: File an enhancement proposal
-labels: ["Type: Enhancement", "Status: Triage"]
+labels: ["enhancement"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
Configure the jira-sync-bot to create issues in Jira for new Github issues (ref https://warthogs.atlassian.net/browse/ISD-2850).