### PR TITLE
Update charmcraft.yaml to use platforms instead of bases

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -39,15 +39,9 @@ requires:
     scope: container
 
 type: charm
-bases:
-  - build-on:
-    - name: ubuntu
-      channel: "22.04"
-    run-on:
-    - name: ubuntu
-      channel: "22.04"
-    - name: "ubuntu"
-      channel: "20.04"
+platforms:
+  ubuntu@24.04:amd64:
+  ubuntu@22.04:amd64:
 
 parts:
   charm:


### PR DESCRIPTION
Removed bases configuration and added platforms for Ubuntu.

Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
