### PR TITLE
chore(integration_test): remove load-test-enabled and zap-enabled no-op flags (charmkeeper)

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -13,10 +13,8 @@ jobs:
     with:
       juju-channel: 3.6/stable
       tmate-debug: false
-      load-test-enabled: false
       trivy-fs-enabled: true
       trivy-image-config: "trivy.yaml"
-      zap-enabled: false
       provider: lxd
   allure-report:
     if: ${{ !cancelled() && github.event_name == 'schedule' }}


### PR DESCRIPTION
Remove `load-test-enabled` and `zap-enabled` from the integration test workflow.

These inputs have been removed from [operator-workflows](https://github.com/canonical/operator-workflows), causing CI failures in this repository. Removing them from the local workflow fixes the failing integration test jobs.

_This PR was created by [Charmkeeper](https://github.com/canonical/charmkeeper)._